### PR TITLE
feat(ui): add support for identity editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A terminal-based tool that helps developers manage multiple Git identities easil
 ## Features
 
 - 🔄 Switch between multiple Git identities with ease
+- 🏷️ Optional nicknames for quick identity identification
 - ➕ Add new identities interactively
 - 🗑️ Delete unwanted identities
 - 💻 Terminal-based UI with keyboard navigation
 - 🔒 Uses Git's built-in configuration system
+- 🔍 Smart identity matching by nickname, name, or email
 
 ## Installation
 
@@ -64,6 +66,7 @@ Run `gitid` to start the interactive interface.
 - `↑`/`↓` or `j`/`k` - Navigate through identities
 - `Enter` - Select identity or confirm action
 - `D` - Delete selected identity
+- `E` - Edit nickname for selected identity
 - `←`/`→` - Navigate confirmation dialog
 - `Esc` - Cancel current action
 - `q` - Quit application
@@ -72,7 +75,19 @@ Run `gitid` to start the interactive interface.
 
 - **Switch Identity**: Select an identity from the list and press Enter
 - **Add Identity**: Select "Add new identity" and follow the prompts
+  - Name and email are required
+  - Nickname is optional but helps with quick identification
+- **Edit Nickname**: Select "Edit nickname" for existing identities
 - **Delete Identity**: Navigate to an identity and press D, then confirm
+
+### Nicknames
+
+Nicknames are optional short identifiers that make it easier to distinguish between identities:
+
+- **Display**: Identities with nicknames show as `nickname (Name <email>)`
+- **Without nicknames**: Shows as `Name <email>` (backwards compatible)
+- **Adding nicknames**: Available when creating new identities or editing existing ones
+- **Smart matching**: Future CLI will support switching by nickname, name, or email
 
 ## Contributing
 

--- a/identity.go
+++ b/identity.go
@@ -142,6 +142,20 @@ func switchIdentityByIdentifier(identifier string) error {
 	return nil
 }
 
+func updateIdentity(oldEmail, newName, newEmail, newNickname string) error {
+	if oldEmail != newEmail {
+		if err := deleteIdentity(oldEmail); err != nil {
+			return fmt.Errorf("error removing old identity: %w", err)
+		}
+	}
+
+	if err := addIdentity(newName, newEmail, newNickname); err != nil {
+		return fmt.Errorf("error adding updated identity: %w", err)
+	}
+
+	return nil
+}
+
 func deleteIdentity(email string) error {
 	section := encodeEmail(email)
 

--- a/ui.go
+++ b/ui.go
@@ -79,6 +79,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.identities) {
 				editNicknameTUI(m.identities[m.cursor])
 				m.identities = getAllIdentities()
+				return m, tea.ClearScreen
 			}
 		case "left", "h":
 			if m.showConfirmation && m.confirmCursor > 0 {

--- a/ui.go
+++ b/ui.go
@@ -75,9 +75,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.identities) {
 				m.showConfirmation = true
 			}
-		case "E", "e":
+		case "e":
 			if m.cursor < len(m.identities) {
 				editNicknameTUI(m.identities[m.cursor])
+				m.identities = getAllIdentities()
+				return m, tea.ClearScreen
+			}
+		case "E":
+			if m.cursor < len(m.identities) {
+				editFullIdentityTUI(m.identities[m.cursor])
 				m.identities = getAllIdentities()
 				return m, tea.ClearScreen
 			}
@@ -161,7 +167,7 @@ func (m Model) View() string {
 
 	helpStyle := lipgloss.NewStyle().Foreground(subtleColor)
 	help := helpStyle.Render("\n" +
-		"↑/k up • ↓/j down • enter select • D delete • E edit nickname • q quit\n" +
+		"↑/k up • ↓/j down • enter select • D delete • e edit nickname • E edit full • q quit\n" +
 		"Confirmation: ←/→ navigate • enter confirm • esc cancel",
 	)
 
@@ -193,6 +199,35 @@ func editNicknameTUI(identity Identity) {
 
 	if err := setNickname(identity.Email, newNickname); err != nil {
 		fmt.Printf("Error setting nickname: %v\n", err)
+	}
+}
+
+func editFullIdentityTUI(identity Identity) {
+	fmt.Printf("Editing identity: %s\n", getIdentityDisplay(identity))
+
+	newName := prompt("Enter name (" + identity.Name + ")")
+	if newName == "" {
+		newName = identity.Name
+	}
+
+	newEmail := prompt("Enter email (" + identity.Email + ")")
+	if newEmail == "" {
+		newEmail = identity.Email
+	}
+
+	currentNickname := getNickname(identity.Email)
+	nicknamePrompt := "Enter nickname"
+	if currentNickname != "" {
+		nicknamePrompt += " (" + currentNickname + ")"
+	}
+	nicknamePrompt += " (leave empty to keep current)"
+	newNickname := prompt(nicknamePrompt)
+	if newNickname == "" {
+		newNickname = currentNickname
+	}
+
+	if err := updateIdentity(identity.Email, newName, newEmail, newNickname); err != nil {
+		fmt.Printf("Error updating identity: %v\n", err)
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -75,6 +75,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.identities) {
 				m.showConfirmation = true
 			}
+		case "E", "e":
+			if m.cursor < len(m.identities) {
+				editNicknameTUI(m.identities[m.cursor])
+				m.identities = getAllIdentities()
+			}
 		case "left", "h":
 			if m.showConfirmation && m.confirmCursor > 0 {
 				m.confirmCursor--
@@ -155,7 +160,7 @@ func (m Model) View() string {
 
 	helpStyle := lipgloss.NewStyle().Foreground(subtleColor)
 	help := helpStyle.Render("\n" +
-		"↑/k up • ↓/j down • enter select • D delete • q quit\n" +
+		"↑/k up • ↓/j down • enter select • D delete • E edit nickname • q quit\n" +
 		"Confirmation: ←/→ navigate • enter confirm • esc cancel",
 	)
 
@@ -173,6 +178,20 @@ func addIdentityTUI() {
 
 	if err := addIdentity(name, email, nickname); err != nil {
 		fmt.Printf("Error adding identity: %v\n", err)
+	}
+}
+
+func editNicknameTUI(identity Identity) {
+	currentNickname := getNickname(identity.Email)
+	if currentNickname == "" {
+		currentNickname = "(none)"
+	}
+
+	fmt.Printf("Current nickname for %s: %s\n", identity.Name, currentNickname)
+	newNickname := prompt("Enter new nickname (leave empty to remove)")
+
+	if err := setNickname(identity.Email, newNickname); err != nil {
+		fmt.Printf("Error setting nickname: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
This pull request adds support for optional nicknames to help users quickly identify and manage their Git identities. It introduces new interactive commands for editing nicknames and full identity details in the terminal UI, updates the documentation, and refactors identity management logic to support these features.

**Identity Management Enhancements:**

* Added support for optional nicknames to identities, including display logic and smart matching for future CLI improvements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R91)
* Introduced the `updateIdentity` function to allow editing name, email, and nickname for an existing identity, handling both update and removal logic.

**Terminal UI Improvements:**

* Added interactive commands: `e` to edit nickname and `E` to edit the full identity (name, email, nickname), with corresponding TUI functions (`editNicknameTUI`, `editFullIdentityTUI`). [[1]](diffhunk://#diff-bcaef4efbe83b371a9c05e40ca6d2d0d27b63e0c9fc169993c9959397f9890ceR78-R89) [[2]](diffhunk://#diff-bcaef4efbe83b371a9c05e40ca6d2d0d27b63e0c9fc169993c9959397f9890ceR191-R233)
* Updated the help text in the UI to reflect new commands for editing nicknames and identities.

**Documentation Updates:**

* Enhanced the `README.md` to describe nickname functionality, new commands, and improved identity matching. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R91)